### PR TITLE
Update region output directory

### DIFF
--- a/scripts/region_generator.py
+++ b/scripts/region_generator.py
@@ -9,7 +9,7 @@ import xtgeo
 from typing import Tuple
 
 
-def create_region_fields(grid: xtgeo.Grid, output_dir: str = "../include/SOLUTION"):
+def create_region_fields(grid: xtgeo.Grid, output_dir: str = "../include/REGIONS"):
     """Generate all region definition fields"""
     
     nx, ny, nz = grid.dimensions


### PR DESCRIPTION
## Summary
- default output_dir in `create_region_fields` now points to `../include/REGIONS`

## Testing
- `python3 -m py_compile scripts/region_generator.py`
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68448aa72534832db060d4acaf5487d0